### PR TITLE
Add error handling

### DIFF
--- a/.safety-policy.yml
+++ b/.safety-policy.yml
@@ -1,4 +1,4 @@
-version: '3.0'
+version: "3.0"
 
 scanning-settings:
   max-depth: 6
@@ -18,7 +18,7 @@ report:
       vulnerabilities:
         70612:
           reason: No fix for this yet
-          expires: '2024-07-31'
+          expires: "2024-08-31"
 
 fail-scan-with-exit-code:
   dependency-vulnerabilities:

--- a/animal_fact_api/facts/views.py
+++ b/animal_fact_api/facts/views.py
@@ -1,7 +1,7 @@
 """Views for animal facts api."""
 
 from django.db.models.functions import Random
-from rest_framework import generics
+from rest_framework import generics, status
 from rest_framework.response import Response
 
 from .models import Fact
@@ -27,5 +27,11 @@ class FactDetail(generics.RetrieveAPIView):
             return self.retrieve(request, *args, **kwargs)
         else:
             random_record = Fact.objects.order_by(Random()).first()
-            serializer = self.get_serializer(random_record)
-            return Response(serializer.data)
+            if random_record:
+                serializer = self.get_serializer(random_record)
+                return Response(serializer.data)
+            else:
+                return Response(
+                    {"detail": "No records found."},
+                    status=status.HTTP_404_NOT_FOUND,
+                )

--- a/animal_fact_api/tests/unit_tests/facts/test_views.py
+++ b/animal_fact_api/tests/unit_tests/facts/test_views.py
@@ -7,27 +7,26 @@ from ....facts.views import FactDetail
 class TestFactView(TestCase):
     def setUp(self):
         self.factory = RequestFactory()
-        Fact.objects.create(animal="dog", fact="A dog fact.")
-        self.fact2 = Fact.objects.create(animal="cat", fact="Some cat fact.")
-        Fact.objects.create(animal="cat", fact="Best cat fact.")
 
     def test_returns_single_fact_when_pk_passed_in(self):
-        request = self.factory.get(f"/facts/{self.fact2.pk}")
-        response = FactDetail.as_view()(request, pk=self.fact2.pk)
+        fact = Fact.objects.create(animal="cat", fact="Some cat fact.")
+        request = self.factory.get(f"/facts/{fact.pk}")
+        response = FactDetail.as_view()(request, pk=fact.pk)
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Some cat fact.")
 
     def test_returns_random_fact_when_no_pk_passed_in(self):
+        Fact.objects.create(animal="dog", fact="A dog fact.")
+        Fact.objects.create(animal="cat", fact="Best cat fact.")
         request = self.factory.get("/facts")
         response = FactDetail.as_view()(request)
         self.assertEqual(response.status_code, 200)
         self.assertIn(
             response.data["fact"],
-            ["A dog fact.", "Some cat fact.", "Best cat fact."],
+            ["A dog fact.", "Best cat fact."],
         )
 
     def test_returns_no_record_response_when_table_is_empty(self):
-        Fact.objects.all().delete()
         request = self.factory.get("/facts")
         response = FactDetail.as_view()(request)
         self.assertEqual(response.status_code, 404)

--- a/animal_fact_api/tests/unit_tests/facts/test_views.py
+++ b/animal_fact_api/tests/unit_tests/facts/test_views.py
@@ -26,7 +26,7 @@ class TestFactView(TestCase):
             ["A dog fact.", "Best cat fact."],
         )
 
-    def test_returns_no_record_response_when_table_is_empty(self):
+    def test_handles_when_there_are_no_records_to_return(self):
         request = self.factory.get("/facts")
         response = FactDetail.as_view()(request)
         self.assertEqual(response.status_code, 404)

--- a/animal_fact_api/tests/unit_tests/facts/test_views.py
+++ b/animal_fact_api/tests/unit_tests/facts/test_views.py
@@ -25,3 +25,10 @@ class TestFactView(TestCase):
             response.data["fact"],
             ["A dog fact.", "Some cat fact.", "Best cat fact."],
         )
+
+    def test_returns_no_record_response_when_table_is_empty(self):
+        Fact.objects.all().delete()
+        request = self.factory.get("/facts")
+        response = FactDetail.as_view()(request)
+        self.assertEqual(response.status_code, 404)
+        self.assertIn(response.data["detail"], "No records found.")


### PR DESCRIPTION
When creating the views, in particular the one for returning a random fact, I didn't handle if there were no facts to return. This MR adds this in, so it now returns a nice, human-readable response if there are no facts to return.

In doing the above, I decided to remove the fact creation from the test setup to within the individual tests. I could have just deleted the facts from the table in the no record test but I felt that this way was better, as well as cleaner as it didn't feel right to add records and then immediately remove them.

Additional note: Also had to update the safety policy as the job failed.